### PR TITLE
Adds support for Unity's new input system.

### DIFF
--- a/Runtime/InputHelper.cs
+++ b/Runtime/InputHelper.cs
@@ -1,0 +1,67 @@
+using UnityEngine.UIElements;
+
+namespace LightScrollSnap
+{
+    public static class InputHelper
+    {
+        public static bool MouseButtonPressed(MouseButton button)
+        {
+#if ENABLE_INPUT_SYSTEM
+            // New Input System
+            var mouse = UnityEngine.InputSystem.Mouse.current;
+            if (mouse != null) {
+                switch (button) {
+                    case MouseButton.LeftMouse:
+                        return mouse.leftButton.isPressed;
+                    case MouseButton.RightMouse:
+                        return mouse.rightButton.isPressed;
+                    case MouseButton.MiddleMouse:
+                        return mouse.middleButton.isPressed;
+                }
+
+                return false;
+            }
+
+            // No mouse device (e.g., phone/tablet). Treat any touch as left mouse.
+            var touchscreen = UnityEngine.InputSystem.Touchscreen.current;
+            if (touchscreen != null) {
+                if (button == MouseButton.LeftMouse) {
+                    // Any finger currently pressed?
+                    for (var i = 0; i < touchscreen.touches.Count; i++) {
+                        if (touchscreen.touches[i].press.isPressed) {
+                            return true;
+                        }
+                    }
+                }
+
+                return false; // right/ middle don't exist on touch.
+            }
+
+            // Generic pointer fallback (e.g., pen)
+            var pointer = UnityEngine.InputSystem.Pointer.current;
+            if (pointer != null && button == MouseButton.LeftMouse) {
+                return pointer.press.isPressed;
+            }
+
+            return false;
+
+#elif ENABLE_LEGACY_INPUT_MANAGER
+            // Old (legacy) Input Manager
+            switch (button) {
+                case MouseButton.LeftMouse:
+                    // On mobile, GetMouseButton(0) is false; map touch to left click.
+                    return UnityEngine.Input.GetMouseButton(0) || UnityEngine.Input.touchCount > 0;
+                case MouseButton.RightMouse:
+                    return UnityEngine.Input.GetMouseButton(1);
+                case MouseButton.MiddleMouse:
+                    return UnityEngine.Input.GetMouseButton(2);
+                default:
+                    return false;
+            }
+#else
+            // Neither system compiled in
+            return false;
+#endif
+        }
+    }
+}

--- a/Runtime/InputHelper.cs.meta
+++ b/Runtime/InputHelper.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 492ea03612fde34478eb2aacd70d3775

--- a/Runtime/ScrollSnap.cs
+++ b/Runtime/ScrollSnap.cs
@@ -15,20 +15,23 @@ namespace LightScrollSnap
 
         [SerializeField] private DeltaTimeMode deltaTimeMode = DeltaTimeMode.Unscaled;
 
-        [Header("Scroll Settings")] [SerializeField]
+        [Header("Scroll Settings")]
+        [SerializeField]
         private Scrollbar scrollbar;
 
-        [SerializeField] [Range(0, 1)] private float initialPos;
+        [SerializeField][Range(0, 1)] private float initialPos;
         public bool autoScrollToClickedItem = true;
         public float smoothScrollDuration = 0.35f;
         public float smoothSnapDuration = 0.25f;
 
-        [Header("Snap Settings")] [SerializeField]
+        [Header("Snap Settings")]
+        [SerializeField]
         private float snapDelayDuration = 0.15f;
 
         [SerializeField] private float snapDistanceThreshold = 0.001f;
 
-        [Header("Effect Settings")] [SerializeField]
+        [Header("Effect Settings")]
+        [SerializeField]
         private List<BaseScrollSnapEffect> effects;
 
         #endregion
@@ -159,7 +162,7 @@ namespace LightScrollSnap
             _scrollPos = scrollbar.value;
             UpdateNearest();
 
-            var leftMouseButtonPressed = MouseButtonPressed(MouseButton.LeftMouse);
+            var leftMouseButtonPressed = InputHelper.MouseButtonPressed(MouseButton.LeftMouse);
             if (leftMouseButtonPressed)
             {
                 ClearSmoothScrolling();
@@ -170,32 +173,6 @@ namespace LightScrollSnap
 
             HandleItemsStates();
             ApplyEffects();
-        }
-
-        private bool MouseButtonPressed(MouseButton button) {
-#if ENABLE_INPUT_SYSTEM
-            switch (button) {
-                case MouseButton.LeftMouse:
-                    return UnityEngine.InputSystem.Mouse.current.leftButton.isPressed;
-                case MouseButton.RightMouse:
-                    return UnityEngine.InputSystem.Mouse.current.rightButton.isPressed;
-                case MouseButton.MiddleMouse:
-                    return UnityEngine.InputSystem.Mouse.current.middleButton.isPressed;
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(button), button, $"Unsupported mouse button: {button}");
-            }
-#else
-            switch (button) {
-                case MouseButton.LeftMouse:
-                    return Input.GetMouseButton(0);
-                case MouseButton.RightMouse:
-                    return Input.GetMouseButton(1);
-                case MouseButton.MiddleMouse:
-                    return Input.GetMouseButton(2);
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(button), button, $"Unsupported mouse button: {button}");
-            }
-#endif
         }
 
         private void UpdateItemsIfChanged()

--- a/Runtime/ScrollSnap.cs
+++ b/Runtime/ScrollSnap.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Events;
 using UnityEngine.UI;
+using UnityEngine.UIElements;
 
 namespace LightScrollSnap
 {
@@ -157,7 +158,9 @@ namespace LightScrollSnap
 
             _scrollPos = scrollbar.value;
             UpdateNearest();
-            if (Input.GetMouseButton(0))
+
+            var leftMouseButtonPressed = MouseButtonPressed(MouseButton.LeftMouse);
+            if (leftMouseButtonPressed)
             {
                 ClearSmoothScrolling();
                 _snapping = false;
@@ -167,6 +170,32 @@ namespace LightScrollSnap
 
             HandleItemsStates();
             ApplyEffects();
+        }
+
+        private bool MouseButtonPressed(MouseButton button) {
+#if ENABLE_INPUT_SYSTEM
+            switch (button) {
+                case MouseButton.LeftMouse:
+                    return UnityEngine.InputSystem.Mouse.current.leftButton.isPressed;
+                case MouseButton.RightMouse:
+                    return UnityEngine.InputSystem.Mouse.current.rightButton.isPressed;
+                case MouseButton.MiddleMouse:
+                    return UnityEngine.InputSystem.Mouse.current.middleButton.isPressed;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(button), button, $"Unsupported mouse button: {button}");
+            }
+#else
+            switch (button) {
+                case MouseButton.LeftMouse:
+                    return Input.GetMouseButton(0);
+                case MouseButton.RightMouse:
+                    return Input.GetMouseButton(1);
+                case MouseButton.MiddleMouse:
+                    return Input.GetMouseButton(2);
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(button), button, $"Unsupported mouse button: {button}");
+            }
+#endif
         }
 
         private void UpdateItemsIfChanged()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.emrecelik95.lightscrollsnap",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "displayName": "Light Scroll Snap",
   "description": "This package contains a basic scroll snap with customizable effects.",
   "unity": "2020.1",


### PR DESCRIPTION
Adds support for Unity's new input system by checking for the `#if ENABLE_INPUT_SYSTEM` directive. This is a quick but effective patch. The newly introduces method could be moved to an input helper class to allow for more modulairity.

Closes #1 .